### PR TITLE
Fixing links in Computer Vision 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ p5js repo for teaching
 * [Bouncing balls and line segments](https://makeabilitylab.github.io/p5js/Vectors/BouncingBallsAndLineSegmentsImproved/): Demonstrates how to use vectors to calculate vectors and reflecting collisions
 
 ## Computer Vision
-* [Hand pose demo](https://makeabilitylab.github.io/p5js/ml5js/Handpose/Demo/): demonstration of the [ml5js](https://ml5js.org/) [handpose library](https://learn.ml5js.org/#/reference/handpose)
-* [Hand wave recognizer](https://makeabilitylab.github.io/p5js/ml5js/Handpose/HandWaveDetector/): wave your hand at the camera
-* [Elmo generator](https://github.com/makeabilitylab/p5js/tree/master/ml5js/PoseNet/ElmoGeneratorMultiperson): turn you and your friends into Elmo in realtime! Uses the [ml5js PoseNet implementation](https://ml5js.org/reference/api-PoseNet/)
+* [Hand pose demo](https://makeabilitylab.github.io/p5js/ml5js/HandPose/HandPoseDemo/): demonstration of the [ml5js](https://ml5js.org/) [handpose library](https://learn.ml5js.org/#/reference/handpose)
+* [Hand wave recognizer](https://makeabilitylab.github.io/p5js/ml5js/HandPose/HandWaveDetector/): wave your hand at the camera
+* [Elmo generator](https://github.com/makeabilitylab/p5js/tree/master/ml5js/PoseNet/ElmoGeneratorMultiperson): turn you and your friends into Elmo in realtime! Uses the [ml5js PoseNet implementation](https://learn.ml5js.org/#/reference/posenet)
 
 ## Games
 * [Pong](https://makeabilitylab.github.io/p5js/Games/Pong): simple [Pong](https://en.wikipedia.org/wiki/Pong) game


### PR DESCRIPTION
I stumbled over this little repository and wanted to test the hand pose estimator stuff. Unfortunately the links were dead. So I updated them.

**In Detail:**

- Handpose was renamed to HandPose
- The link to the posenet reference was updated